### PR TITLE
Party-Kennungen BT-29/BT-46: schemeID-Behandlung korrigiert (UBL-SR-16, CII-SR-450)

### DIFF
--- a/intf.Invoice.pas
+++ b/intf.Invoice.pas
@@ -643,8 +643,8 @@ type
     Address : TInvoiceAddress;
 
     IdentifierSellerBuyer : String; //BT-29 Kreditor-Nr AccountingSupplierParty / BT-46 Debitor-Nr AccountingCustomerParty
-    GlobalIdentifierSellerBuyer : String; //BT-29-0, BT-46-0, optional nur CII
-    GlobalIdentifierSellerBuyerSchemeID : String; //BT-29-1, BT-46-1, optional nur CII, Werte 0021 : SWIFT, 0088 : EAN, 0060 : DUNS, 0177 : ODETTE
+    GlobalIdentifierSellerBuyer : String; //BT-29-0, BT-46-0, optional, CII: ram:GlobalID, UBL: cac:PartyIdentification/cbc:ID mit schemeID
+    GlobalIdentifierSellerBuyerSchemeID : String; //BT-29-1, BT-46-1, Default 0088 (GLN), Werte 0021 : SWIFT, 0088 : EAN/GLN, 0060 : DUNS, 0177 : ODETTE
     BankAssignedCreditorIdentifier : String; //Glaeubiger-ID (BT-90)
 
     VATCompanyID : String;   //BT-31 UStID

--- a/intf.XRechnung_3_0.pas
+++ b/intf.XRechnung_3_0.pas
@@ -169,15 +169,21 @@ var
       _Party.ElectronicAddressSellerBuyer := node.text;
       _Party.ElectronicAddressSellerBuyerSchemeID := TXRechnungXMLHelper.SelectAttributeText(node,'schemeID');
     end;
+    //IDs mit schemeID (z.B. 0088 GLN) gehoeren zur GlobalID (BT-29-0/BT-46-0), IDs ohne schemeID zur Kennung (BT-29/BT-46)
     if TXRechnungXMLHelper.SelectNodes(_Node,'.//cac:PartyIdentification',nodes) then
     for i := 0 to nodes.length-1 do
     if TXRechnungXMLHelper.SelectNode(nodes.item[i],'.//cbc:ID',node) then
     begin
-      if SameText(TXRechnungXMLHelper.SelectAttributeText(node,'schemeID'),'0088') then
-        _Party.IdentifierSellerBuyer := node.text
-      else
       if SameText(TXRechnungXMLHelper.SelectAttributeText(node,'schemeID'),'SEPA') then
-        _Party.BankAssignedCreditorIdentifier := node.text;
+        _Party.BankAssignedCreditorIdentifier := node.text
+      else
+      if TXRechnungXMLHelper.SelectAttributeText(node,'schemeID') <> '' then
+      begin
+        _Party.GlobalIdentifierSellerBuyer := node.text;
+        _Party.GlobalIdentifierSellerBuyerSchemeID := TXRechnungXMLHelper.SelectAttributeText(node,'schemeID');
+      end
+      else
+        _Party.IdentifierSellerBuyer := node.text;
     end;
     _Party.Name := TXRechnungXMLHelper.SelectNodeText(_Node,'.//cac:PartyName/cbc:Name');
     _Party.Address.StreetName := TXRechnungXMLHelper.SelectNodeText(_Node,'.//cac:PostalAddress/cbc:StreetName');
@@ -1356,12 +1362,16 @@ begin
       Attributes['schemeID'] := ifthen(_Invoice.AccountingSupplierParty.ElectronicAddressSellerBuyerSchemeID='','EM',_Invoice.AccountingSupplierParty.ElectronicAddressSellerBuyerSchemeID);
       Text := _Invoice.AccountingSupplierParty.ElectronicAddressSellerBuyer;
     end;
-    if _Invoice.AccountingSupplierParty.IdentifierSellerBuyer <> '' then
+    //GlobalID (z.B. GLN) als eigene PartyIdentification mit schemeID,
+    //Verkaeuferkennung (BT-29) ohne schemeID - die Kennung ist keine GLN
+    if _Invoice.AccountingSupplierParty.GlobalIdentifierSellerBuyer <> '' then
     with AddChild('cac:PartyIdentification').AddChild('cbc:ID') do
     begin
-      Attributes['schemeID'] := '0088';
-      Text := _Invoice.AccountingSupplierParty.IdentifierSellerBuyer;
+      Attributes['schemeID'] := IfThen(_Invoice.AccountingSupplierParty.GlobalIdentifierSellerBuyerSchemeID = '','0088',_Invoice.AccountingSupplierParty.GlobalIdentifierSellerBuyerSchemeID);
+      Text := _Invoice.AccountingSupplierParty.GlobalIdentifierSellerBuyer;
     end;
+    if _Invoice.AccountingSupplierParty.IdentifierSellerBuyer <> '' then
+      AddChild('cac:PartyIdentification').AddChild('cbc:ID').Text := _Invoice.AccountingSupplierParty.IdentifierSellerBuyer;
     if _Invoice.AccountingSupplierParty.BankAssignedCreditorIdentifier <> '' then
     with AddChild('cac:PartyIdentification').AddChild('cbc:ID') do
     begin
@@ -1425,12 +1435,17 @@ begin
       Attributes['schemeID'] := ifthen(_Invoice.AccountingCustomerParty.ElectronicAddressSellerBuyerSchemeID='','EM',_Invoice.AccountingCustomerParty.ElectronicAddressSellerBuyerSchemeID);
       Text := _Invoice.AccountingCustomerParty.ElectronicAddressSellerBuyer;
     end;
-    if _Invoice.AccountingCustomerParty.IdentifierSellerBuyer <> '' then
+    //BT-46 ist in UBL max. einmal erlaubt (UBL-SR-16) - GlobalID (z.B. GLN) hat Vorrang
+    //vor der Kaeuferkennung; Kennung ohne GlobalID ohne schemeID (die Kennung ist keine GLN)
+    if _Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyer <> '' then
     with AddChild('cac:PartyIdentification').AddChild('cbc:ID') do
     begin
-      Attributes['schemeID'] := '0088';
-      Text := _Invoice.AccountingCustomerParty.IdentifierSellerBuyer;
-    end;
+      Attributes['schemeID'] := IfThen(_Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyerSchemeID = '','0088',_Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyerSchemeID);
+      Text := _Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyer;
+    end
+    else
+    if _Invoice.AccountingCustomerParty.IdentifierSellerBuyer <> '' then
+      AddChild('cac:PartyIdentification').AddChild('cbc:ID').Text := _Invoice.AccountingCustomerParty.IdentifierSellerBuyer;
     if _Invoice.AccountingCustomerParty.Name <> '' then
     with AddChild('cac:PartyName') do
     begin
@@ -2052,7 +2067,10 @@ begin
       end;
       with AddChild('ram:BuyerTradeParty') do
       begin
-        if _Invoice.AccountingCustomerParty.IdentifierSellerBuyer <> '' then
+        //BT-46 nur einmal belegen (CII-SR-450) - GlobalID hat Vorrang vor ram:ID,
+        //nur im Extended-Profil sind beide zusammen erlaubt (keine EN16931-CIUS)
+        if (_Invoice.AccountingCustomerParty.IdentifierSellerBuyer <> '') and
+           ((_Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyer = '') or (_Profile = ipZUGFeRDExtended)) then
           AddChild('ram:ID').Text := _Invoice.AccountingCustomerParty.IdentifierSellerBuyer;
         if _Invoice.AccountingCustomerParty.GlobalIdentifierSellerBuyer <> '' then
         with AddChild('ram:GlobalID') do


### PR DESCRIPTION
## Problem

Beim Erzeugen von Rechnungen mit Käufer-/Verkäufer-Kennungen entstehen Schematron-Beanstandungen der EN-16931-Validierung (z. B. KoSIT-Validator, valitool.org):

1. **UBL:** `IdentifierSellerBuyer` (BT-29 Kreditor-Nr. / BT-46 Debitor-Nr.) wird immer als `cac:PartyIdentification/cbc:ID` mit hartem `schemeID="0088"` geschrieben. 0088 (ISO/IEC 6523) bedeutet aber „GLN" — eine Kreditor-/Debitor-Nummer ist keine GLN. Empfängersysteme, die die Kennung als GLN interpretieren, laufen ins Leere.
2. **UBL:** Für `GlobalIdentifierSellerBuyer` (BT-29-0/BT-46-0, z. B. eine echte GLN) gibt es im UBL-Writer keine Ausgabe — die Felder sind laut Kommentar „nur CII". GS1-Empfänger fordern die GLN aber auch im UBL-Format (BT-46 mit Scheme 0088).
3. **CII:** Sind `IdentifierSellerBuyer` und `GlobalIdentifierSellerBuyer` beide gefüllt, schreibt der CII-Writer beim `BuyerTradeParty` `ram:ID` **und** `ram:GlobalID`. Das verletzt **CII-SR-450** („Only one buyer identifier should be present (either the ID or the Global ID)").

## Änderungen

**UBL-Writer (Seller & Buyer):**
- `GlobalIdentifierSellerBuyer` wird als eigene `cac:PartyIdentification/cbc:ID` mit `schemeID` ausgegeben (Default 0088, überschreibbar via `GlobalIdentifierSellerBuyerSchemeID`).
- `IdentifierSellerBuyer` wird ohne `schemeID` ausgegeben (BT-29/BT-46 erlauben eine Kennung ohne Scheme).
- Beim **Buyer** wird wegen **UBL-SR-16** („Buyer identifier shall occur maximum once") nur eine `PartyIdentification` geschrieben — die GlobalID hat Vorrang, sonst die Kennung. Beim **Seller** ist BT-29 laut EN 16931 0..n, dort werden ggf. beide ausgegeben (zusätzlich zur SEPA-Gläubiger-ID wie bisher).

**UBL-Reader (symmetrisch):**
- `cbc:ID` mit `schemeID` (außer SEPA) → `GlobalIdentifierSellerBuyer` + `GlobalIdentifierSellerBuyerSchemeID`
- `cbc:ID` ohne `schemeID` → `IdentifierSellerBuyer`

**CII-Writer (BuyerTradeParty):**
- `ram:ID` wird nur noch geschrieben, wenn keine GlobalID vorhanden ist — **außer** im Profil `ipZUGFeRDExtended`: Extended ist keine EN16931-CIUS, dort sind `ram:ID` und `ram:GlobalID` gemeinsam zulässig und werden weiterhin beide ausgegeben.
- SellerTradeParty unverändert (BT-29 ist 0..n, keine entsprechende CII-SR-Regel).

**intf.Invoice.pas:** Kommentare der beiden Felder aktualisiert („optional nur CII" gilt nicht mehr).

## Vorher/Nachher (UBL, Buyer mit Debitor-Nr. „20003" und GLN)

Vorher:
```xml
<cac:PartyIdentification>
  <cbc:ID schemeID="0088">20003</cbc:ID> <!-- Debitor-Nr. faelschlich als GLN deklariert -->
</cac:PartyIdentification>
```

Nachher:
```xml
<cac:PartyIdentification>
  <cbc:ID schemeID="0088">4123450000027</cbc:ID> <!-- echte GLN aus GlobalIdentifierSellerBuyer -->
</cac:PartyIdentification>
```

## Getestet

- KoSIT-Validator (XRechnung 3.0): CII-SR-450-Warnung verschwindet, keine neuen Beanstandungen; UBL validiert ohne UBL-SR-16-Verstoß.
- Roundtrip Schreiben→Lesen: GLN landet wieder in `GlobalIdentifierSellerBuyer(SchemeID)`, Kennung in `IdentifierSellerBuyer`.
- Hintergrund: Ein GS1-fordernder Rechnungsempfänger verlangte `BuyerTradeParty/ram:GlobalID[@schemeID='0088']` (BT-46-1) — mit dieser Änderung erfüllbar, ohne CII-SR-450 zu verletzen.

## Hinweis für Bestandsnutzer

`IdentifierSellerBuyer` wird im UBL nicht mehr mit `schemeID="0088"` gekennzeichnet. Wer bisher tatsächlich eine GLN in dieses Feld geschrieben hat, sollte sie künftig in `GlobalIdentifierSellerBuyer` übergeben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
